### PR TITLE
BAH-3440 | Fixed. order line qty logic changed.

### DIFF
--- a/bahmni_account/__manifest__.py
+++ b/bahmni_account/__manifest__.py
@@ -10,7 +10,7 @@ Bahmni Account
     'category': 'Account',
     'website': '',
     'images': [],
-    'depends': ['account'],
+    'depends': ['account','account_payment','sale'],
     'data': [
              'views/account_invoice_view.xml',
              'views/company_view.xml',

--- a/bahmni_api_feed/models/api_event_worker.py
+++ b/bahmni_api_feed/models/api_event_worker.py
@@ -94,7 +94,7 @@ class ApiEventWorker(models.Model):
 
     @api.model
     def _find_country(self, address):
-        return self.env['res.company'].search([], limit=1).partner_id.country_id
+        return self.env['res.country'].search([('name', '=', address.get('country'))], limit=1)
 
     @api.model
     def _find_or_create_level3(self, state, district, level_name, auto_create_customer_address_levels):
@@ -138,7 +138,8 @@ class ApiEventWorker(models.Model):
         res.update({'ref': vals.get('ref'),
                     'name': vals.get('name'),
                     'local_name': vals.get('local_name') if vals.get('local_name') else False,
-                    'uuid': vals.get('uuid')})
+                    'uuid': vals.get('uuid'),
+                    'customer_rank':  1})
         address_data = vals.get('preferredAddress')
         # get validated address details
         address_details = self._get_address_details(address_data)
@@ -162,11 +163,10 @@ class ApiEventWorker(models.Model):
                 created_village = village_master.create({'name': address_data.get('cityVillage')})
                 customer_master.village_id = created_village.id
 
-        if attributes['email'] and cust_id:
+        if attributes.get('email') and cust_id:
             customer_master = self.env['res.partner'].search([('id', '=', cust_id)])
             if customer_master:
                 customer_master.email = attributes['email']
-                customer_master.customer_rank = 1 ##Make a partner as a customer
 
         if address_data.get('country') and cust_id:
             country_master = self.env['res.country']

--- a/bahmni_api_feed/models/order_save_service.py
+++ b/bahmni_api_feed/models/order_save_service.py
@@ -347,8 +347,12 @@ class OrderSaveService(models.Model):
         self._create_sale_order_line_function(sale_order, order)
         
     @api.model
-    def _get_order_quantity(self, order, default_quantity_value):
+    def _get_order_quantity(self, order, default_quantity_value, product_default_uom):
         if(not self.env['syncable.units.mapping'].search([('name', '=', order['quantityUnits'])])):
+            _logger.info("No syncable unit mapping found for unit: %s, while mapping order for %s\
+                    "%(order['quantityUnits'],order['productName']))
+            return default_quantity_value
+        if product_default_uom.id != self.env['syncable.units.mapping'].search([('name', '=', order['quantityUnits'])], limit=1).id:
             return default_quantity_value
         return order['quantity']
 
@@ -359,9 +363,11 @@ class OrderSaveService(models.Model):
         if(uom_ids):
             uom_id = uom_ids.ids[0]
             uom_obj = self.env['syncable.units.mapping'].browse(uom_id)
-            if(uom_obj.unit_of_measure):
+            if uom_obj.unit_of_measure.id == product_default_uom.id:
                 return uom_obj.unit_of_measure.id
-        return product_default_uom
+        _logger.info("%s uom expected %s, but found %s"\
+                %(order_line['productName'],order_line['quantityUnits'],product_default_uom.name))
+        return product_default_uom.id
 
     @api.model
     def _create_sale_order_line_function(self, sale_order, order):
@@ -380,8 +386,8 @@ class OrderSaveService(models.Model):
             _logger.info(default_quantity_total)
             default_quantity_value = 0
 
-            order['quantity'] = self._get_order_quantity(order, default_quantity_value)
-            order_line_uom = self._get_order_line_uom(order, prod_obj.uom_id.id)
+            order['quantity'] = self._get_order_quantity(order, default_quantity_value, prod_obj.uom_id)
+            order_line_uom = self._get_order_line_uom(order, prod_obj.uom_id)
             product_uom_qty = order['quantity']
             if(prod_lot != None and order['quantity'] > prod_lot.stock_forecast and prod_lot.stock_forecast > 0):
                 product_uom_qty = prod_lot.stock_forecast

--- a/bahmni_api_feed/models/order_save_service.py
+++ b/bahmni_api_feed/models/order_save_service.py
@@ -378,9 +378,7 @@ class OrderSaveService(models.Model):
             default_quantity_total = self.env['res.config.settings'].group_default_quantity
             _logger.info("DEFAULT QUANTITY TOTAL")
             _logger.info(default_quantity_total)
-            default_quantity_value = 1
-            if default_quantity_total and len(default_quantity_total.users) > 0:
-                default_quantity_value = -1
+            default_quantity_value = 0
 
             order['quantity'] = self._get_order_quantity(order, default_quantity_value)
             order_line_uom = self._get_order_line_uom(order, prod_obj.uom_id.id)

--- a/bahmni_api_feed/models/order_save_service.py
+++ b/bahmni_api_feed/models/order_save_service.py
@@ -352,7 +352,8 @@ class OrderSaveService(models.Model):
             _logger.info("No syncable unit mapping found for unit: %s, while mapping order for %s\
                     "%(order['quantityUnits'],order['productName']))
             return default_quantity_value
-        if product_default_uom.id != self.env['syncable.units.mapping'].search([('name', '=', order['quantityUnits'])], limit=1).id:
+        uom_identified = self.env['syncable.units.mapping'].search([('name', '=', order['quantityUnits'])], limit=1)
+        if product_default_uom.id != uom_identified.unit_of_measure.id if uom_identified else False:
             return default_quantity_value
         return order['quantity']
 
@@ -365,6 +366,7 @@ class OrderSaveService(models.Model):
             uom_obj = self.env['syncable.units.mapping'].browse(uom_id)
             if uom_obj.unit_of_measure.id == product_default_uom.id:
                 return uom_obj.unit_of_measure.id
+        
         _logger.info("%s uom expected %s, but found %s"\
                 %(order_line['productName'],order_line['quantityUnits'],product_default_uom.name))
         return product_default_uom.id

--- a/bahmni_sale/models/sale_order_line.py
+++ b/bahmni_sale/models/sale_order_line.py
@@ -17,6 +17,12 @@ class SaleOrderLine(models.Model):
                                help="Flag to identify whether drug order is dispensed or not.")
     lot_id = fields.Many2one('stock.lot', string="Batch No")
     expiry_date = fields.Datetime(string="Expiry date")
+
+    product_uom_qty = fields.Float(
+        string="Quantity",
+        compute='_compute_product_uom_qty',
+        digits='Product Unit of Measure', default=0.0,
+        store=True, readonly=False, required=True, precompute=True)
     
     @api.onchange('lot_id')
     def onchange_lot_id(self):


### PR DESCRIPTION
Jira --> [BAH-3440](https://bahmni.atlassian.net/browse/BAH-3440)

In this PR following changes all done.

1. While creating the order with miss matched UOM in the odoo the qty create as a 0 qty.
2. In odoo inbuilt module sale have the field product_uom_qty default value as 1, while using the inheritance changed the default value as 0.
3. While creating the order throw the API the sale order default value changes a 0 instead of 1.