### PR TITLE
BAH-3564 | Add dbFilter to show all the databases created with Odoo

### DIFF
--- a/package/docker/odoo/odoo.conf
+++ b/package/docker/odoo/odoo.conf
@@ -2,6 +2,7 @@
 addons_path = /mnt/extra-addons,/opt/bahmni-erp/bahmni-addons
 data_dir = /var/lib/odoo
 db_name = odoo
+dbfilter = .*
 limit_time_cpu = 1700
 limit_time_real = 1700
 ; admin_passwd = admin
@@ -9,7 +10,6 @@ limit_time_real = 1700
 ; db_maxconn = 64
 ; db_name = False
 ; db_template = template1
-; dbfilter = .*
 ; debug_mode = False
 ; email_from = False
 ; limit_memory_hard = 2684354560


### PR DESCRIPTION
This PR adds dbFIlter configuration to odoo.conf which will allow implementations to create multiple databases within a single instance of Odoo.