### PR TITLE
BAH-3562 | Fix. Show the actual quantity and unit passed in payload in the description of sale order line

### DIFF
--- a/bahmni_api_feed/models/order_save_service.py
+++ b/bahmni_api_feed/models/order_save_service.py
@@ -392,7 +392,7 @@ class OrderSaveService(models.Model):
             product_uom_qty = order['quantity']
             if(prod_lot != None and order['quantity'] > prod_lot.stock_forecast and prod_lot.stock_forecast > 0):
                 product_uom_qty = prod_lot.stock_forecast
-            description = " ".join([str(actual_quantity), str(order.get('quantityUnits', None))])
+            description = " ".join([prod_obj.name, "-", str(actual_quantity), str(order.get('quantityUnits', None))])
             order_line_dispensed = True if order.get('dispensed') == 'true' or (order.get('dispensed') and order.get('dispensed') != 'false') else False
             sale_order_line = {
                 'product_id': prod_id[0],

--- a/bahmni_api_feed/models/order_save_service.py
+++ b/bahmni_api_feed/models/order_save_service.py
@@ -381,7 +381,6 @@ class OrderSaveService(models.Model):
             prod_lot = sale_order_line_obj.get_available_batch_details(prod_id, sale_order)
 
             actual_quantity = order['quantity']
-            comments = " ".join([str(actual_quantity), str(order.get('quantityUnits', None))])
 
             default_quantity_total = self.env['res.config.settings'].group_default_quantity
             _logger.info("DEFAULT QUANTITY TOTAL")
@@ -393,7 +392,7 @@ class OrderSaveService(models.Model):
             product_uom_qty = order['quantity']
             if(prod_lot != None and order['quantity'] > prod_lot.stock_forecast and prod_lot.stock_forecast > 0):
                 product_uom_qty = prod_lot.stock_forecast
-            description = " ".join([prod_obj.name, "- Total", str(product_uom_qty), str(order.get('quantityUnits', None))])
+            description = " ".join([str(actual_quantity), str(order.get('quantityUnits', None))])
             order_line_dispensed = True if order.get('dispensed') == 'true' or (order.get('dispensed') and order.get('dispensed') != 'false') else False
             sale_order_line = {
                 'product_id': prod_id[0],


### PR DESCRIPTION
This PR updates the description field of Sale order line in quotation to show the actual quantity and unit of measure passed in the API payload.

Medications in Bahmni:
<img width="972" alt="image" src="https://github.com/Bahmni/bahmni-odoo-modules/assets/31698165/947f63fe-a6e1-49d8-af1d-65c7da1d40c2">

Quotation in Odoo 16:
<img width="1097" alt="image" src="https://github.com/Bahmni/bahmni-odoo-modules/assets/31698165/bc4a3b26-f96d-4f23-8907-3d3ee6b12524">
