### PR TITLE
BAH-3638 | Add. Automate delivery process based on sale order confirmation.

### DIFF
--- a/bahmni_sale/models/__init__.py
+++ b/bahmni_sale/models/__init__.py
@@ -7,3 +7,4 @@ from . import pos
 from . import account_invoice
 from . import shop
 from . import stock_move
+from . import stock_move_line

--- a/bahmni_sale/models/sale_order.py
+++ b/bahmni_sale/models/sale_order.py
@@ -266,10 +266,6 @@ class SaleOrder(models.Model):
                     for mv_line in picking.move_ids.mapped('move_line_ids'):
                         if not mv_line.qty_done and mv_line.reserved_qty or mv_line.reserved_uom_qty:
                             mv_line.qty_done = mv_line.reserved_qty or mv_line.reserved_uom_qty      
-                        else:
-                            ...
-            else:
-                ...
         return res
 
 

--- a/bahmni_sale/models/stock_move_line.py
+++ b/bahmni_sale/models/stock_move_line.py
@@ -1,3 +1,7 @@
+## This files is copied from https://github.com/odoo/odoo/blob/16.0/addons/stock/models/stock_move_line.py
+## To override the User Error message.
+
+
 from collections import Counter, defaultdict
 
 from odoo import _, api, fields, tools, models
@@ -9,7 +13,11 @@ from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
+
     def _action_done(self):
+           
+        Quant = self.env['stock.quant']
+
         ml_ids_tracked_without_lot = OrderedSet()
         ml_ids_to_delete = OrderedSet()
         ml_ids_to_create_lot = OrderedSet()

--- a/bahmni_sale/models/stock_move_line.py
+++ b/bahmni_sale/models/stock_move_line.py
@@ -1,0 +1,110 @@
+from collections import Counter, defaultdict
+
+from odoo import _, api, fields, tools, models
+from odoo.exceptions import UserError, ValidationError
+from odoo.tools import OrderedSet, groupby
+from odoo.tools.float_utils import float_compare, float_is_zero, float_round
+from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def _action_done(self):
+        ml_ids_tracked_without_lot = OrderedSet()
+        ml_ids_to_delete = OrderedSet()
+        ml_ids_to_create_lot = OrderedSet()
+        for ml in self:
+            # Check here if `ml.qty_done` respects the rounding of `ml.product_uom_id`.
+            uom_qty = float_round(ml.qty_done, precision_rounding=ml.product_uom_id.rounding, rounding_method='HALF-UP')
+            precision_digits = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+            qty_done = float_round(ml.qty_done, precision_digits=precision_digits, rounding_method='HALF-UP')
+            if float_compare(uom_qty, qty_done, precision_digits=precision_digits) != 0:
+                raise UserError(_('The quantity done for the product "%s" doesn\'t respect the rounding precision '
+                                  'defined on the unit of measure "%s". Please change the quantity done or the '
+                                  'rounding precision of your unit of measure.') % (ml.product_id.display_name, ml.product_uom_id.name))
+
+            qty_done_float_compared = float_compare(ml.qty_done, 0, precision_rounding=ml.product_uom_id.rounding)
+            if qty_done_float_compared > 0:
+                if ml.product_id.tracking != 'none':
+                    picking_type_id = ml.move_id.picking_type_id
+                    if picking_type_id:
+                        if picking_type_id.use_create_lots:
+                            # If a picking type is linked, we may have to create a production lot on
+                            # the fly before assigning it to the move line if the user checked both
+                            # `use_create_lots` and `use_existing_lots`.
+                            if ml.lot_name and not ml.lot_id:
+                                lot = self.env['stock.lot'].search([
+                                    ('company_id', '=', ml.company_id.id),
+                                    ('product_id', '=', ml.product_id.id),
+                                    ('name', '=', ml.lot_name),
+                                ], limit=1)
+                                if lot:
+                                    ml.lot_id = lot.id
+                                else:
+                                    ml_ids_to_create_lot.add(ml.id)
+                        elif not picking_type_id.use_create_lots and not picking_type_id.use_existing_lots:
+                            # If the user disabled both `use_create_lots` and `use_existing_lots`
+                            # checkboxes on the picking type, he's allowed to enter tracked
+                            # products without a `lot_id`.
+                            continue
+                    elif ml.is_inventory:
+                        # If an inventory adjustment is linked, the user is allowed to enter
+                        # tracked products without a `lot_id`.
+                        continue
+
+                    if not ml.lot_id and ml.id not in ml_ids_to_create_lot:
+                        ml_ids_tracked_without_lot.add(ml.id)
+            elif qty_done_float_compared < 0:
+                raise UserError(_('No negative quantities allowed'))
+            elif not ml.is_inventory:
+                ml_ids_to_delete.add(ml.id)
+
+        if ml_ids_tracked_without_lot:
+            mls_tracked_without_lot = self.env['stock.move.line'].browse(ml_ids_tracked_without_lot)
+            raise UserError(_('Stock not available for the following products in %s shop \n - %s \n'%(
+                   ', '.join(mls_tracked_without_lot.mapped('location_id.name'))\
+                  if mls_tracked_without_lot.mapped('location_id.name') else False,\
+                  '\n - '.join(mls_tracked_without_lot.mapped('product_id.display_name'))\
+                  if mls_tracked_without_lot.mapped('product_id.display_name') else False)))
+        ml_to_create_lot = self.env['stock.move.line'].browse(ml_ids_to_create_lot)
+        ml_to_create_lot.with_context(bypass_reservation_update=True)._create_and_assign_production_lot()
+
+        mls_to_delete = self.env['stock.move.line'].browse(ml_ids_to_delete)
+        mls_to_delete.unlink()
+
+        mls_todo = (self - mls_to_delete)
+        mls_todo._check_company()
+
+        # Now, we can actually move the quant.
+        ml_ids_to_ignore = OrderedSet()
+        for ml in mls_todo:
+            if ml.product_id.type == 'product':
+                rounding = ml.product_uom_id.rounding
+
+                # if this move line is force assigned, unreserve elsewhere if needed
+                if not ml.move_id._should_bypass_reservation(ml.location_id) and float_compare(ml.qty_done, ml.reserved_uom_qty, precision_rounding=rounding) > 0:
+                    qty_done_product_uom = ml.product_uom_id._compute_quantity(ml.qty_done, ml.product_id.uom_id, rounding_method='HALF-UP')
+                    extra_qty = qty_done_product_uom - ml.reserved_qty
+                    ml._free_reservation(ml.product_id, ml.location_id, extra_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, ml_ids_to_ignore=ml_ids_to_ignore)
+                # unreserve what's been reserved
+                if not ml.move_id._should_bypass_reservation(ml.location_id) and ml.product_id.type == 'product' and ml.reserved_qty:
+                    Quant._update_reserved_quantity(ml.product_id, ml.location_id, -ml.reserved_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, strict=True)
+
+                # move what's been actually done
+                quantity = ml.product_uom_id._compute_quantity(ml.qty_done, ml.move_id.product_id.uom_id, rounding_method='HALF-UP')
+                available_qty, in_date = Quant._update_available_quantity(ml.product_id, ml.location_id, -quantity, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id)
+                if available_qty < 0 and ml.lot_id:
+                    # see if we can compensate the negative quants with some untracked quants
+                    untracked_qty = Quant._get_available_quantity(ml.product_id, ml.location_id, lot_id=False, package_id=ml.package_id, owner_id=ml.owner_id, strict=True)
+                    if untracked_qty:
+                        taken_from_untracked_qty = min(untracked_qty, abs(quantity))
+                        Quant._update_available_quantity(ml.product_id, ml.location_id, -taken_from_untracked_qty, lot_id=False, package_id=ml.package_id, owner_id=ml.owner_id)
+                        Quant._update_available_quantity(ml.product_id, ml.location_id, taken_from_untracked_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id)
+                Quant._update_available_quantity(ml.product_id, ml.location_dest_id, quantity, lot_id=ml.lot_id, package_id=ml.result_package_id, owner_id=ml.owner_id, in_date=in_date)
+            ml_ids_to_ignore.add(ml.id)
+        # Reset the reserved quantity as we just moved it to the destination location.
+        mls_todo.with_context(bypass_reservation_update=True).write({
+            'reserved_uom_qty': 0.00,
+            'date': fields.Datetime.now(),
+        })
+


### PR DESCRIPTION
Jira --> [BAH-3638](https://bahmni.atlassian.net/browse/BAH-3638)

In this PR below changes updated.

While checking the sale order confirm auto delivery logic was implemented with the boolean config field, we can able to control the automation logic with the config setting, with available in the odoo settings.

Once the sale order confirm automatically delivery will get confirmed, as per the logic stock will reused in the mapped lot in the sale order line.

**Following controls all added in the Sale order.**

1. If the mapped lot not having available Qty means system will indicate that the  qty engouht qty not avaiable with the available qty details.
2. If the same product mapped twice with the same lot number means system will  indicate that the same product same lot mapped twice, user remove the line and increase the qty in the one line and move further.
3. Sale order mapped lot not available in the mapped shop means based on the product wise system will indicate the warning.


![image](https://github.com/Bahmni/bahmni-odoo-modules/assets/35575433/e4503d5f-f883-4823-ae2e-dc43a4dcba60)
