### PR TITLE
Fix. Module dependency error and container failing to start

### DIFF
--- a/bahmni_purchase/__manifest__.py
+++ b/bahmni_purchase/__manifest__.py
@@ -11,7 +11,7 @@ Bahmni Purchase
     'category': 'Product',
     'website': '',
     'images': [],
-    'depends': ['purchase', 'bahmni_product', 'bahmni_stock'],
+    'depends': ['purchase', 'bahmni_product', 'bahmni_stock', 'bahmni_sale'],
     'data': ['security/ir.model.access.csv',
 			 'views/purchase_views.xml',
              'views/product_view.xml',


### PR DESCRIPTION
This PR adds bahmni_sale as a dependency of bahmni_purchase, since the purchase module adds a menu item to the Bahmni Masters menu