### PR TITLE
Refactor. Hide From and To location fields in internal transfer page

### DIFF
--- a/bahmni_stock/views/stock_pick_lot_view.xml
+++ b/bahmni_stock/views/stock_pick_lot_view.xml
@@ -25,6 +25,12 @@
 			<xpath expr="//tree/field[@name='qty_done']" position="after">	
 				<field name="balance"/>
 			</xpath>
+			<xpath expr="//tree/field[@name='location_id'][2]" position="attributes">
+				<attribute name="attrs">{'column_invisible': [['parent.picking_type_code', 'in', ['incoming','internal']]]}</attribute>
+			</xpath>
+			<xpath expr="//tree/field[@name='location_dest_id'][2]" position="attributes">
+				<attribute name="attrs">{'column_invisible': [['parent.picking_type_code', 'in', ['incoming','internal']]]}</attribute>
+			</xpath>
 		</field>
 	</record>
 	


### PR DESCRIPTION
This PR hides the `From` and `To` fields in the internal transfer page detailed operations section, as the location will be selected above