### PR TITLE
Refactor. Bundling of community modules in docker image

### DIFF
--- a/package/docker/odoo/Dockerfile
+++ b/package/docker/odoo/Dockerfile
@@ -12,13 +12,9 @@ COPY bahmni_purchase ${ADDON_PATH}/bahmni_purchase/
 COPY bahmni_sale ${ADDON_PATH}/bahmni_sale/
 COPY bahmni_stock ${ADDON_PATH}/bahmni_stock/
 COPY restful_api ${ADDON_PATH}/restful_api/
-COPY community_modules/base_account_budget ${ADDON_PATH}/base_account_budget/
-COPY community_modules/base_accounting_kit ${ADDON_PATH}/base_accounting_kit/
-COPY community_modules/report_pdf_options ${ADDON_PATH}/report_pdf_options/
-COPY community_modules/stock_picking_filter_lot ${ADDON_PATH}/stock_picking_filter_lot
-COPY community_modules/br_custom_list_view ${ADDON_PATH}/br_custom_list_view
 COPY openerp7_data_import ${ADDON_PATH}/openerp7_data_import/
 COPY bahmni_reports ${ADDON_PATH}/bahmni_reports
+COPY community_modules ${ADDON_PATH}/community_modules/
 COPY package/resources/data/address.seed.csv ${ADDON_PATH}/bahmni_initializer/data/
 COPY package/resources/data/uom_seed.xml ${ADDON_PATH}/bahmni_initializer/data/
 COPY package/resources/data/order_type.xml ${ADDON_PATH}/bahmni_initializer/data/

--- a/package/docker/odoo/odoo.conf
+++ b/package/docker/odoo/odoo.conf
@@ -1,5 +1,5 @@
 [options]
-addons_path = /mnt/extra-addons,/opt/bahmni-erp/bahmni-addons
+addons_path = /mnt/extra-addons,/opt/bahmni-erp/bahmni-addons,/opt/bahmni-erp/bahmni-addons/community_modules
 data_dir = /var/lib/odoo
 db_name = odoo
 dbfilter = .*
@@ -31,8 +31,8 @@ limit_time_real = 1700
 ; smtp_user = False
 ; workers = 0
 ; xmlrpc = True
-; xmlrpc_interface = 
+; xmlrpc_interface =
 ; xmlrpc_port = 8069
 ; xmlrpcs = True
-; xmlrpcs_interface = 
+; xmlrpcs_interface =
 ; xmlrpcs_port = 8071


### PR DESCRIPTION
This PR refactors the way community modules are bundled into the docker image.
- All the modules downloaded from Odoo Community is grouped under community_modules directory.
- The docker image bundles it inside the `/opt/bahmni-erp/bahmni-addons/community_modules` directory.
- The addition path is added to `odoo.conf` 