### PR TITLE
BAH-3776 | Fix. Serial number alignment issue in Accounting/Invoices Views

### DIFF
--- a/community_modules/br_custom_list_view/static/src/xml/record_highlight.xml
+++ b/community_modules/br_custom_list_view/static/src/xml/record_highlight.xml
@@ -3,6 +3,17 @@
         <xpath expr="//table/thead/tr/th[@t-if='hasSelectors']" position="before">
             <th>Sl No</th>
         </xpath>
+        <xpath expr="//table/tfoot/tr/td[1]" position="before">
+            <td></td>
+        </xpath>
+    </t>
+    <t t-name="br_custom_list_view.AccountRenderer" t-inherit="account.ListRenderer" t-inherit-mode="extension" owl="1">
+        <xpath expr="//table/thead/tr/th[@t-if='hasSelectors']" position="before">
+            <th>Sl No</th>
+        </xpath>
+        <xpath expr="//table/tfoot/tr/td[1]" position="before">
+            <td></td>
+        </xpath>
     </t>
     <t t-name="br_custom_list_view.add_number" t-inherit="web.ListRenderer.Rows" t-inherit-mode="extension" owl="1">
         <xpath expr="//t[@t-foreach='list.records']" position="before">


### PR DESCRIPTION
This PR fixes the alignment issues happening in Invoices page when custom module for row numbers is installed. https://apps.odoo.com/apps/modules/16.0/br_custom_list_view/

JIRA --> https://bahmni.atlassian.net/browse/BAH-3776

Before:
<img width="1788" alt="Screenshot 2024-04-25 at 10 32 18 PM" src="https://github.com/Bahmni/bahmni-odoo-modules/assets/31698165/80a2a938-6fe5-493e-b2f8-733881f5090b">

After:
<img width="1790" alt="image" src="https://github.com/Bahmni/bahmni-odoo-modules/assets/31698165/a7f709ac-918b-4b7f-8c57-61f702f05ed0">
