### PR TITLE
BAH-3828 | Add. Redirect to payments on sale order confirmation based on user toggle

### DIFF
--- a/bahmni_sale/security/security_groups.xml
+++ b/bahmni_sale/security/security_groups.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-	
+
 	<record id="group_allow_change_qty" model="res.groups">
 		<field name="name">Allow default quantity to set as -1</field>
 		<field name="category_id" ref="base.module_category_hidden"/>
 	</record>
-	
+
 	<record id="group_allow_change_so_charge" model="res.groups">
 		<field name="name">Allow to set Chargeable amount for Sales Order</field>
 		<field name="category_id" ref="base.module_category_hidden"/>
 	</record>
-	
+
+	<record id="bahmni_sale.group_redirect_to_payments_on_sale_confirm" model="res.groups">
+		<field name="name">Redirect to Payments on Sale Order Confirmation</field>
+		<field name="category_id" ref="base.module_category_hidden"/>
+	</record>
+
 </odoo>


### PR DESCRIPTION
This PR adds in the feature to redirect the user to Payments screen on confirming the sale order. This happens only when auto invoice validation is enabled and redirection is enabled under user technical rights.