### PR TITLE
BAH-3702 | Fix. Customer/Vendor added from Sale-Order/Purchase-Order forms are not getting customer_rank/supplier_rank

### DIFF
--- a/bahmni_purchase/views/purchase_views.xml
+++ b/bahmni_purchase/views/purchase_views.xml
@@ -10,8 +10,8 @@
 				<field name="date_order"/>
 			</xpath>
 			
-			<xpath expr="//field[@name='partner_id']" position="after">
-				<field name="partner_id" domain="[('supplier_rank', '>', 0)]" invisible="1"/>
+			<xpath expr="//field[@name='partner_id']" position="attributes">
+				<attribute name="domain">[('supplier_rank', '&gt;', 0)]</attribute>
 			</xpath>
 			<xpath expr="//tree/field[@name='price_unit']" position="after">
 				<field name="mrp"/>

--- a/bahmni_sale/views/sale_order_views.xml
+++ b/bahmni_sale/views/sale_order_views.xml
@@ -12,8 +12,10 @@
 				<field name="provider_name" attrs="{'readonly': [('state', 'not in', ['draft', 'sent'])]}"/>
 			</xpath>
 			<xpath expr="//field[@name='partner_id']" position="after">
-				<field name="partner_id" domain="[('customer_rank', '>', 0)]" invisible="1"/>
 				<field name="partner_uuid" invisible="1"/>
+			</xpath>
+			<xpath expr="//field[@name='partner_id']" position="attributes">
+				<attribute name="domain">[('customer_rank', '&gt;', 0)]</attribute>
 			</xpath>
 			<xpath expr="//field[@name='payment_term_id']" position="after">
 				<field name="shop_id" attrs="{'readonly': [('state', 'not in', ['draft', 'sent'])]}"/>


### PR DESCRIPTION
In xml views for sale_order/purchase_order, the domain filter was getting added to a duplicate **partner_id** field - because there was the attribute **after**  instead of **attributes** to add the required domain filter. 
Changed it to attribute **attributes** to add the attribute on the existing partner_id field (and also changed the syntax accordingly)