### PR TITLE
BAH-4006 | Fix. Digit precision for lot specific price details

### DIFF
--- a/bahmni_stock/models/stock_move_line.py
+++ b/bahmni_stock/models/stock_move_line.py
@@ -8,9 +8,9 @@ from odoo.exceptions import UserError, ValidationError, AccessError, RedirectWar
 class StockMoveLine(models.Model):
     _inherit = 'stock.move.line'
 
-    sale_price = fields.Float(string="Sale Price")
-    mrp = fields.Float(string="MRP")
-    cost_price = fields.Float(string="Cost Price")
+    sale_price = fields.Float(string="Sale Price", digits='Product Price')
+    mrp = fields.Float(string="MRP", digits='Product Price')
+    cost_price = fields.Float(string="Cost Price", digits='Product Price')
     balance = fields.Float(string="Balance")
     existing_lot_id = fields.Many2one(
         'stock.lot', 'Lot/Serial Number',

--- a/bahmni_stock/models/stock_production_lot.py
+++ b/bahmni_stock/models/stock_production_lot.py
@@ -88,9 +88,9 @@ class StockProductionLot(models.Model):
                         product_uom = self.env['product.uom'].browse(product_uom_id)
                         lot.stock_forecast = result[0].get('sum') * product_uom.factor
 
-    sale_price = fields.Float(string="Sale Price")
-    mrp = fields.Float(string="MRP")
-    cost_price = fields.Float(string="Cost Price")
+    sale_price = fields.Float(string="Sale Price", digits='Product Price')
+    mrp = fields.Float(string="MRP", digits='Product Price')
+    cost_price = fields.Float(string="Cost Price", digits='Product Price')
     stock_forecast = fields.Float(string="Available forecast",
                                      compute=_get_future_stock_forecast,store=True,
                                      digits=dp.get_precision('Product Unit of Measure'),


### PR DESCRIPTION
This PR adds `digits` attribute to custom price specific fields for lot based price information.
This is to keep in sync with product price precision as defined in default Odoo. https://github.com/odoo/odoo/blob/16.0/addons/product/models/product_product.py#L26