### PR TITLE
BAH-3963 | Fix. Disable creation of lots from Sales page

### DIFF
--- a/bahmni_sale/views/sale_order_views.xml
+++ b/bahmni_sale/views/sale_order_views.xml
@@ -93,11 +93,11 @@
 	
 			
 			<xpath expr="//field[@name='order_line']/tree/field[@name='qty_delivered']" position="after">
-				<field name="lot_id" context = "{'parent_shop_id':parent.shop_id}" domain="['|',('expiration_date','&gt;', datetime.datetime.combine(context_today(), datetime.time(23,59,59))),('expiration_date','=',False),('product_qty','>' ,0),('product_id','=',product_id)]"/>
+				<field name="lot_id" context = "{'parent_shop_id':parent.shop_id}" options="{'no_quick_create':True,'no_create_edit':True,'no_open': True,}" domain="['|',('expiration_date','&gt;', datetime.datetime.combine(context_today(), datetime.time(23,59,59))),('expiration_date','=',False),('product_qty','>' ,0),('product_id','=',product_id)]"/>
 				<field name="expiry_date" force_save="1" readonly="1"/>
 			</xpath>
 			<xpath expr="//field[@name='order_line']/form/group/group/field[@name='price_unit']" position="after">
-				<field name="lot_id" context = "{'parent_shop_id':parent.shop_id}" domain="['|',('expiration_date','&gt;', datetime.datetime.combine(context_today(), datetime.time(23,59,59))),('expiration_date','=',False),('product_qty','>' ,0),('product_id','=',product_id)]"/>
+				<field name="lot_id" context = "{'parent_shop_id':parent.shop_id}" options="{'no_quick_create':True,'no_create_edit':True,'no_open': True,}" domain="['|',('expiration_date','&gt;', datetime.datetime.combine(context_today(), datetime.time(23,59,59))),('expiration_date','=',False),('product_qty','>' ,0),('product_id','=',product_id)]"/>
 				<field name="expiry_date" readonly="1"/>
 			</xpath>
 			<xpath expr="//field[@name='order_line']/tree/field[@name='product_template_id']" position="replace">


### PR DESCRIPTION
This PR disables the creation of lots from Sales Quotation page. 
Creation of lots and quantity modifications should only done from Purchase flows or Inventory flows.

JIRA: https://bahmni.atlassian.net/browse/BAH-3963