### PR TITLE
BAH-3964 | Fix. Check for quantity availability only for product_lines in Sale Quotation lines

### DIFF
--- a/bahmni_sale/models/sale_order.py
+++ b/bahmni_sale/models/sale_order.py
@@ -381,6 +381,8 @@ class SaleOrder(models.Model):
     #So Once we Confirm the sale order it will create the invoice and ask for the register payment.
     def action_confirm(self):
         for line in self.order_line:
+           if line.display_type in ('line_section', 'line_note'):
+               continue
            if line.product_uom_qty <=0:
                raise UserError("Quantity for %s is %s. Please update the quantity or remove the product line."%(line.product_id.name,line.product_uom_qty))
            if line.product_id.tracking == 'lot' and not line.lot_id:

--- a/bahmni_sale/views/sale_order_views.xml
+++ b/bahmni_sale/views/sale_order_views.xml
@@ -23,9 +23,9 @@
 
 
 			<xpath expr="//tree" position="attributes">
-				<attribute name="decoration-danger">product_uom_qty&lt;=0</attribute>
-				<attribute name="decoration-bf">product_uom_qty&lt;=0</attribute>
-				<attribute name="decoration-it">product_uom_qty&lt;=0</attribute>
+				<attribute name="decoration-danger">product_uom_qty&lt;=0 and display_type!='line_section' and display_type!='line_note'</attribute>
+				<attribute name="decoration-bf">product_uom_qty&lt;=0 and display_type!='line_section' and display_type!='line_note'</attribute>
+				<attribute name="decoration-it">product_uom_qty&lt;=0 and display_type!='line_section' and display_type!='line_note'</attribute>
 			</xpath>
 
 			<xpath expr="//group[@name='note_group']" position="replace">


### PR DESCRIPTION
This PR adds a check to run the product quantity availability validations only for lines with product and excludes line types note and section.

JIRA: https://bahmni.atlassian.net/browse/BAH-3964