### PR TITLE
BAH-4054 | Fix. File permissions for Odoo conf file

### DIFF
--- a/package/docker/odoo/Dockerfile
+++ b/package/docker/odoo/Dockerfile
@@ -2,7 +2,10 @@ FROM odoo:16.0
 
 ENV ADDON_PATH=/opt/bahmni-erp/bahmni-addons
 
+USER root
 COPY package/docker/odoo/odoo.conf /etc/odoo/odoo.conf
+RUN chown -R odoo:odoo /etc/odoo
+
 COPY bahmni_account ${ADDON_PATH}/bahmni_account/
 COPY bahmni_address_mapping ${ADDON_PATH}/bahmni_address_mapping/
 COPY bahmni_api_feed ${ADDON_PATH}/bahmni_api_feed/
@@ -23,4 +26,5 @@ COPY package/resources/data/order_type.xml ${ADDON_PATH}/bahmni_initializer/data
 COPY package/resources/data/sale_shop.xml ${ADDON_PATH}/bahmni_initializer/data/
 RUN pip3 install python-decouple
 
+USER odoo
 CMD ["odoo", "-u", "all", "-i", "sale_management,purchase,stock,point_of_sale,l10n_generic_coa,bahmni_account,bahmni_product,bahmni_api_feed,bahmni_stock,bahmni_purchase,bahmni_address_mapping,bahmni_sale,restful_api,bahmni_reports,bahmni_auto_payment_reconciliation", "--without-demo", "-d odoo"]


### PR DESCRIPTION
This PR fixes the file ownership set for `odoo.conf` file. This is crucial in persisting the database master password of Odoo. Without this ownership Odoo fails to write the updated password with an error `ERROR: couldn't write the config file` 

JIRA: https://bahmni.atlassian.net/browse/BAH-4054