### PR TITLE
BAH-4151 | Fix. Invoice amount double calculation due to Odoo base upgrade

### DIFF
--- a/bahmni_sale/models/sale_order.py
+++ b/bahmni_sale/models/sale_order.py
@@ -371,8 +371,7 @@ class SaleOrder(models.Model):
             'disc_acc_id': self.disc_acc_id.id,
             'discount': tot_discount,
             'round_off_amount': self.round_off_amount,
-            'order_id': self.id,
-            'amount_total': self.amount_total,
+            'order_id': self.id
         }
         return invoice_vals
 


### PR DESCRIPTION
This PR fixes the issue with the calculation of Invoice Amount due when confirming a sale order. This happens because the discount and round off are applied twice since the recalculation of amount_total field is disabled in base Odoo by this [commit](https://github.com/odoo/odoo/commit/cc3a060e67a2f1015ea02b589dcf6a7e7eff1e90).