### PR TITLE
BAH-4861 | Add. Adding index for external_order_id in sale_order_line

### DIFF
--- a/bahmni_sale/models/sale_order_line.py
+++ b/bahmni_sale/models/sale_order_line.py
@@ -17,7 +17,8 @@ class SaleOrderLine(models.Model):
     external_id = fields.Char(string="External ID",
                               help="This field is used to store encounter ID of bahmni api call")
     external_order_id = fields.Char(string="External Order ID",
-                                    help="This field stores the order ID got from api call.")
+                                    help="This field stores the order ID got from api call.",
+                                    index=True)
     order_uuid = fields.Char(string="Order UUID",
                              help="Field for generating a random unique ID.")
     dispensed = fields.Boolean(string="Dispensed",

--- a/bahmni_sale/models/sale_order_line.py
+++ b/bahmni_sale/models/sale_order_line.py
@@ -18,7 +18,7 @@ class SaleOrderLine(models.Model):
                               help="This field is used to store encounter ID of bahmni api call")
     external_order_id = fields.Char(string="External Order ID",
                                     help="This field stores the order ID got from api call.",
-                                    index=True)
+                                    index='btree_not_null')
     order_uuid = fields.Char(string="Order UUID",
                              help="Field for generating a random unique ID.")
     dispensed = fields.Boolean(string="Dispensed",


### PR DESCRIPTION
The external_order_id field in the sale.order.line model is frequently used for lookups by the Bahmni API feed. Adding a B-tree index (index=True) on this column improves query performance when searching/filtering sale order lines by their external order ID.